### PR TITLE
Dutch localisation and decimal separator local

### DIFF
--- a/instruction_language.json
+++ b/instruction_language.json
@@ -1,25 +1,27 @@
 {
     "NL": {
+        "locale": "nl_NL",
         "countdown game": {
-            "window caption": "Rock-Paper-Scissors Game",
-            "home": "Press any key to Play",
+            "window caption": "Steen, papier, schaar spel",
+            "home": "Druk op een toets om te spelen",
             "r": "Steen",
             "p": "Papier",
             "s": "Schaar"
         },
         "slowmo game": {
-            "window caption": "Slow-Motion Prediction Game",
-            "home": "Press any key to replay a slow-motion video",
-            "r": "You predicted Rock",
-            "p": "You predicted Paper",
-            "s": "You predicted Scissors",
-            "continue": "Press any key to continue",
-            "pred time": "{prediction_text} in {prediction_time:.2f}s (real time: {real_speed_prediction_time:.2f}s)",
-            "AI predict": "AI predicted {label} with {conf:.1f}% confidence",
-            "AI latest predict": "AI last predicted {label} with {conf:.1f}% confidence"
+            "window caption": "Slow motion gokspel",
+            "home": "Druk op een toets om een slow motion video opnieuw te herhalen",
+            "r": "Jij hebt Steen gekozen",
+            "p": "Jij hebt Papier gekozen",
+            "s": "Jij hebt Schaar gekozen",
+            "continue": "Druk op een toets om door te gaan",
+            "pred time": "{prediction_text} in {prediction_time:.2n} s vertraagde tijd, (normale tijd: {real_speed_prediction_time:.2n} s)",
+            "AI predict": "De AI voorspelde {label} met een zekerheid van {conf:.3n} %",
+            "AI latest predict": "De AI voorspelde als laatst {label} met een zekerheid van {conf:.3n} %"
         }
     },
     "ENG": {
+        "locale": "en_GB",
         "countdown game": {
             "window caption": "Rock-Paper-Scissors Game",
             "home": "Press any key to Play",
@@ -34,9 +36,9 @@
             "p": "You predicted Paper",
             "s": "You predicted Scissors",
             "continue": "Press any key to continue",
-            "pred time": "{prediction_text} in {prediction_time:.2f}s (real time: {real_speed_prediction_time:.2f}s)",
-            "AI predict": "AI predicted {label} with {conf:.1f}% confidence",
-            "AI latest predict": "AI last predicted {label} with {conf:.1f}% confidence"
+            "pred time": "{prediction_text} in {prediction_time:.2n}s slow-motion time, (normal time: {real_speed_prediction_time:.2n}s)",
+            "AI predict": "AI predicted {label} with {conf:.3n}% confidence",
+            "AI latest predict": "AI last predicted {label} with {conf:.3n}% confidence"
         }
     }
 

--- a/slowmo_game.py
+++ b/slowmo_game.py
@@ -9,9 +9,10 @@ import threading
 import cv2
 from camera_slow_motion import convert_to_slow_motion
 import queue
-import keyboard 
+import keyboard
+import locale
 
-LANG = "ENG"
+LANG = "NL"
 
 RAW_DIR = "raw_recordings"
 SLOWMO_DIR = "game_slow_motion_recordings"
@@ -163,11 +164,25 @@ def find_closest_prediction(predictions, target_ts, offset_sec=0.0):
 
     return pred, latest_valid_pred
 
+def get_locale_label(label):
+    match label:
+        case "Rock":
+            return "r"
+        case "Paper":
+            return "p"
+        case "Scissors":
+            return "s"
+        case _:
+            # TODO: handle this?
+            return " "
+
 # ---------------- Pygame main loop ---------------- #
 def main():
     text_display = None
     with open("instruction_language.json", "r", encoding="utf-8") as f:
         text_display = json.load(f)
+
+    locale.setlocale(locale.LC_ALL, f"{text_display[LANG]['locale']}.UTF-8")
 
     x, y = 1600, 300
     os.environ['SDL_VIDEO_WINDOW_POS'] = "%d,%d" % (x,y)
@@ -297,16 +312,20 @@ def main():
                             prediction_time=prediction_time,
                             real_speed_prediction_time=real_speed_prediction_time
                         )
-                pred_surface = font.render(f"{prediction_text} in {prediction_time:.2f}s (real time: {real_speed_prediction_time:.2f}s)", True, TEXT_COLOR)
+                pred_surface = font.render(text, True, TEXT_COLOR)
                 screen.blit(pred_surface, pred_surface.get_rect(center=(WIDTH//2, HEIGHT-90)))
+
+                label = get_locale_label(AI_pred["label"])
                 text = text_display[LANG]["slowmo game"]["AI predict"].format(
-                            label=AI_pred["label"],
+                            label=text_display[LANG]["countdown game"][label],
                             conf=AI_pred["conf"] * 100
                         )
                 # pred_surface = font.render(text, True, TEXT_COLOR)
                 # screen.blit(pred_surface, pred_surface.get_rect(center=(WIDTH//2, HEIGHT-55)))
+
+                label = get_locale_label(AI_latest_pred["label"])
                 text = text_display[LANG]["slowmo game"]["AI latest predict"].format(
-                            label=AI_latest_pred["label"],
+                            label=text_display[LANG]["countdown game"][label],
                             conf=AI_latest_pred["conf"] * 100
                         )
                 pred_surface = font.render(text, True, TEXT_COLOR)


### PR DESCRIPTION
Hey,

Created a pull request instead.

I've added Dutch translations, and also changed the English sentence for "pred time" in an attempt to make it clearer.

Added some extras to the code, so that numbers are converted for a specific localisation. For example, the Dutch use commas as decimal separators and dots to separate large numbers. "Downside" to this implementation is that instead of defining a max number of decimals with `.2f`,  it's now a max number of most significant figures with `.2n`.

Finally I've added a match case to convert the AI labels to a label for the language.json; otherwise, it would use the English label in `AI predict` and `AI latest predict` while the rest of the text would be a different language.